### PR TITLE
fix(a11y): replace aria-label with title on label elements

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -140,7 +140,7 @@
 
     {{- /* navbar, at left side, it's a drawer on mobile */ -}}
     <aside aria-label="Sidebar" class="drawer-side h-screen scrollbar-hidden z-50">
-      <label for="drawer" aria-label="close sidebar" class="drawer-overlay"></label>
+      <label for="drawer" title="Close sidebar" class="drawer-overlay"></label>
       {{- /* sidebar content */ -}}
       <div class="flex h-full w-80 flex-col bg-base-200">
         {{- /* logo zone PC, hidden on mobile */ -}}

--- a/layouts/partials/body/navbar.html
+++ b/layouts/partials/body/navbar.html
@@ -2,7 +2,7 @@
   <div class="navbar-start">
     {{- if ne .Language.LanguageCode "en" }}
     <label
-      aria-label="Open menu"
+      title="Open menu"
       for="drawer"
       class="btn btn-square btn-ghost drawer-button lg:hidden"
     >


### PR DESCRIPTION
## Summary

Fix W3C HTML validation errors where `aria-label` was incorrectly used on `<label>` elements associated with labelable elements (checkbox inputs).

**Note**: The W3C validator's language detection info message ("This document appears to be written in English...") is intentionally NOT addressed. This is only an informational hint, not an error/validation failure. zh-Hans pages should keep `lang="zh-Hans"` even when containing lots of English code.

## Changes

- **baseof.html**: Replace `aria-label="close sidebar"` with `title="Close sidebar"` on drawer overlay label
- **navbar.html**: Replace `aria-label="Open menu"` with `title="Open menu"` on drawer toggle label

## Background

W3C HTML Validator reports:
> The "aria-label" attribute must not be used on any "label" element that is associated with a labelable element.

The `title` attribute provides the same accessibility benefit (screen reader announcement) and visual tooltip without violating HTML validation rules.

## Verification

Before fix: 2 W3C validation errors on every page
After fix: 0 W3C validation errors ✅