### PR TITLE
feat: integrate Hypothesis web annotation for preview environment

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,6 +10,8 @@
 
     {{- partialCached "head/css.html" . -}}
 
+    {{- partial "head/hypothesis.html" . -}}
+
     {{- if hugo.IsProduction -}}
       {{- /* google cmp tag */ -}}
       {{- if site.Params.GoogleTagManager.CookiebotTag -}}

--- a/layouts/partials/head/hypothesis.html
+++ b/layouts/partials/head/hypothesis.html
@@ -1,0 +1,5 @@
+{{- if not hugo.IsProduction -}}
+  {{- /* Hypothesis - Web Annotation Tool for preview environment only */ -}}
+  {{- /* Only loads in non-production environments for annotation and review */ -}}
+  <script async src="https://hypothes.is/embed.js"></script>
+{{- end -}}


### PR DESCRIPTION
## Summary

Add Hypothesis web annotation tool integration that only loads in non-production environments.

## Changes

- Created layouts/partials/head/hypothesis.html with conditional loading
- Modified layouts/_default/baseof.html to include the partial
- Uses {{ if not hugo.IsProduction }} to ensure it only loads in development/preview

## Purpose

Enables real-time annotation and review on preview deployments without affecting production site.

## Testing

- Development build includes Hypothesis script
- Production build excludes Hypothesis script
- Works with Hugos environment detection

## Notes

Uses Hypothesis free tier which is sufficient for personal blog annotation needs.